### PR TITLE
pulumi_state_splitter: state_file: sort resource dependencies

### DIFF
--- a/utilities/pulumi_state_splitter/pulumi_state_splitter/state_file.py
+++ b/utilities/pulumi_state_splitter/pulumi_state_splitter/state_file.py
@@ -27,6 +27,8 @@ def sorted_resources(
     output = {}
 
     def dependencies_first(resource: pulumi_state_splitter.model.Resource):
+        resource = resource.model_copy()
+        resource.dependencies = sorted(resource.dependencies)
         # https://github.com/pulumi/pulumi/blob/91bcce1/pkg/resource/deploy/snapshot.go#L194
         dependencies = resource.dependencies.copy()
         # https://github.com/pulumi/pulumi/blob/91bcce1/pkg/resource/deploy/snapshot.go#L156
@@ -36,7 +38,6 @@ def sorted_resources(
         # https://github.com/pulumi/pulumi/blob/91bcce1/pkg/resource/deploy/snapshot.go#L166
         if resource.parent:
             dependencies.append(resource.parent)
-        dependencies.sort()
         for dependency in dependencies:
             dependencies_first(urn2resource[dependency])
         output.setdefault(resource.urn, resource)

--- a/utilities/pulumi_state_splitter/tests/data.py
+++ b/utilities/pulumi_state_splitter/tests/data.py
@@ -32,6 +32,9 @@ def resources():
                 urn="resource_2",
                 dependencies=[
                     "resource_3",
+                    "resource_7",
+                    "resource_6",
+                    "resource_5",
                     "resource_1",
                 ],
             ),
@@ -54,6 +57,18 @@ def resources():
                 type="provider",
                 id=provider_id,
                 urn=provider_urn,
+            ),
+            pulumi_state_splitter.model.Resource(
+                type="foo",
+                urn="resource_5",
+            ),
+            pulumi_state_splitter.model.Resource(
+                type="foo",
+                urn="resource_7",
+            ),
+            pulumi_state_splitter.model.Resource(
+                type="foo",
+                urn="resource_6",
             ),
         ]
     )

--- a/utilities/pulumi_state_splitter/tests/test_state_file.py
+++ b/utilities/pulumi_state_splitter/tests/test_state_file.py
@@ -55,21 +55,35 @@ class TestStateFilePure(unittest.TestCase):
 
     def test_sorted_resources_with_dependencies(self):
         """Testing sorting of the resources with dependencies."""
-        got = [
-            resource.urn
+        got = {
+            resource.urn: resource
             for resource in pulumi_state_splitter.state_file.sorted_resources(
                 data.resources().values()
             )
-        ]
+        }
         want = [
             "resource_0",
             "resource_1",
             "urn:pulumi:test-stack::test-project::pulumi:providers:provider::default",
             "resource_3",
+            "resource_5",
+            "resource_6",
+            "resource_7",
             "resource_2",
             "resource_4",
         ]
-        self.assertEqual(got, want)
+        self.assertEqual(list(got), want)
+
+        self.assertEqual(
+            got["resource_2"].dependencies,
+            [
+                "resource_1",
+                "resource_3",
+                "resource_5",
+                "resource_6",
+                "resource_7",
+            ],
+        )
 
     def test_path(self):
         """Testing the `StateFile.path` property."""


### PR DESCRIPTION
This is to avoid spurious differences after pulumi up due to different ordering of the resource dependencies.