### PR TITLE
do not persist sourcePosition of resources

### DIFF
--- a/utilities/pulumi_state_splitter/pulumi_state_splitter/model.py
+++ b/utilities/pulumi_state_splitter/pulumi_state_splitter/model.py
@@ -24,6 +24,9 @@ class Resource(pydantic.BaseModel):
 
     file_exclude: ClassVar = {
         "parent_resource",
+        # This is a position in the SDK, not the Pulumi program and
+        # can change in a different environment (e.g. CI vs local),
+        # causing huge state diffs, so ignoring.
         "sourcePosition",
     }
 

--- a/utilities/pulumi_state_splitter/pulumi_state_splitter/model.py
+++ b/utilities/pulumi_state_splitter/pulumi_state_splitter/model.py
@@ -22,7 +22,10 @@ class Resource(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(extra="allow")
 
-    file_exclude: ClassVar = {"parent_resource"}
+    file_exclude: ClassVar = {
+        "parent_resource",
+        "sourcePosition",
+    }
 
     dependencies: Optional[List[str]] = pydantic.Field(default_factory=list)
     outputs: Optional[Mapping[str, Any]] = None

--- a/utilities/pulumi_state_splitter/tests/test_split.py
+++ b/utilities/pulumi_state_splitter/tests/test_split.py
@@ -20,6 +20,11 @@ _TRIVIAL_MODEL = pulumi_state_splitter.model.State(
 )
 
 
+def _maybe_delattr(obj, name):
+    if hasattr(obj, name):
+        delattr(obj, name)
+
+
 class TestStateDirPure(unittest.TestCase):
     """Testing `StateDir` without filesystem interactions."""
 
@@ -133,6 +138,8 @@ class TestStateDirFilesystem(util.TmpDirTest):
 
     _STACK_STATE = data.stack_state()
     _RESOURCES = _STACK_STATE["checkpoint"]["latest"].pop("resources")
+    for r in _RESOURCES:
+        r.pop("sourcePosition", None)
     _RESOURCES[1].pop("outputs")
     _RESOURCES[4]["dependencies"].sort()
     _DIRECTORY = util.Directory(
@@ -197,6 +204,7 @@ class TestStateDirFilesystem(util.TmpDirTest):
         for state in state_dir.state, want:
             state.checkpoint.latest.resources.sort(key=util.resource_key)
             for resource in state.checkpoint.latest.resources:
+                _maybe_delattr(resource, "sourcePosition")
                 resource.dependencies.sort()
 
         self.assertEqual(

--- a/utilities/pulumi_state_splitter/tests/test_split.py
+++ b/utilities/pulumi_state_splitter/tests/test_split.py
@@ -20,7 +20,7 @@ _TRIVIAL_MODEL = pulumi_state_splitter.model.State(
 )
 
 
-def _maybe_delattr(obj, name):
+def _delattr_if_exists(obj, name):
     if hasattr(obj, name):
         delattr(obj, name)
 
@@ -204,7 +204,7 @@ class TestStateDirFilesystem(util.TmpDirTest):
         for state in state_dir.state, want:
             state.checkpoint.latest.resources.sort(key=util.resource_key)
             for resource in state.checkpoint.latest.resources:
-                _maybe_delattr(resource, "sourcePosition")
+                _delattr_if_exists(resource, "sourcePosition")
                 resource.dependencies.sort()
 
         self.assertEqual(


### PR DESCRIPTION
It causes big state diffs if ran in a different
environment (venv path, CI vs local etc.).

It's a reference to the location of the SDK code, not the Pulumi program code, so it's not very useful.

Pulumi seems happy without it.