### PR TITLE
pulumi_state_splitter: tolerate missing parents in corrupt state

### DIFF
--- a/utilities/pulumi_state_splitter/pulumi_state_splitter/model.py
+++ b/utilities/pulumi_state_splitter/pulumi_state_splitter/model.py
@@ -46,7 +46,7 @@ class Resource(pydantic.BaseModel):
             urn2resource[resource.urn] = resource.model_copy()
         for resource in urn2resource.values():
             if resource.parent:
-                resource.parent_resource = urn2resource[resource.parent]
+                resource.parent_resource = urn2resource.get(resource.parent)
         return list(urn2resource.values())
 
     @property

--- a/utilities/pulumi_state_splitter/pulumi_state_splitter/state_file.py
+++ b/utilities/pulumi_state_splitter/pulumi_state_splitter/state_file.py
@@ -38,7 +38,8 @@ def sorted_resources(
             dependencies.append(resource.parent)
         dependencies.sort()
         for dependency in dependencies:
-            dependencies_first(urn2resource[dependency])
+            if dependency in urn2resource:
+                dependencies_first(urn2resource[dependency])
         output.setdefault(resource.urn, resource)
 
     for resource in urn2resource.values():


### PR DESCRIPTION
find_parents (model.py) and sorted_resources/dependencies_first (state_file.py) both did hard dict lookups that raised KeyError when a resource's parent URN was absent from the state - e.g. after a cloud resource was deleted and a Pulumi refresh removed only the parent but left its children behind.

PSS crashing in __exit__ of Unsplitter meant every stack operation - even preview on an unrelated stack - was broken, because Unsplitter re-splits all stacks on exit.

Use .get() / guard with 'in' so PSS survives the corrupt state and lets Pulumi's own --disable-integrity-checking take it from there.