### PR TITLE
pulumi_state_splitter: stop losing trailing dots in resource names

### DIFF
--- a/utilities/pulumi_state_splitter/pulumi_state_splitter/split.py
+++ b/utilities/pulumi_state_splitter/pulumi_state_splitter/split.py
@@ -97,8 +97,7 @@ class StateDir(pulumi_state_splitter.stored_state.StoredState):
             directory = pathlib.Path()
         type_dir_name = resource.type.replace(":", "-")  # für Windows
         basename = resource.name.strip("/").replace("/", "-")
-        path = directory / type_dir_name / basename
-        return path.with_suffix(".yaml")
+        return directory / type_dir_name / "f{basename}.yaml"
 
     def save(self):
         """Writes the contents of the state to a directory."""


### PR DESCRIPTION
Issue introduced in fc2425e743bfcbe2d4a403d7347eac927618a1ea and caused by this behavior:

```console
filip.zyzniewski@LTW64V4D4Y ~ % python3.14
Python 3.14.6 (main, Jun 10 2026, 10:03:53) [Clang 21.0.0 (clang-2100.0.123.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pathlib
>>> pathlib.Path("foo.").with_suffix(".yaml")
PosixPath('foo.yaml')
>>> 
```