### PR TITLE
pulumi_state_splitter: split.StateDir.load: do not explode on state without stack

### DIFF
--- a/utilities/pulumi_state_splitter/pulumi_state_splitter/split.py
+++ b/utilities/pulumi_state_splitter/pulumi_state_splitter/split.py
@@ -102,16 +102,18 @@ class StateDir(pulumi_state_splitter.stored_state.StoredState):
         if not self.state.checkpoint.latest:
             return
         if self.outputs_only:
+            stack_resource_path = self.path / self.resource_subpath(
+                pulumi_state_splitter.model.Resource(
+                    type=self.stack_name.ROOT_STACK_TYPE,
+                    urn=self.stack_name.urn,
+                ),
+            )
+            # `pulumi stack new` does not create the stack resource
+            # and we do not want to explode on such state here.
+            if not stack_resource_path.exists():
+                return
             self.state.checkpoint.latest.resources = [
-                self._load_resource(
-                    self.path
-                    / self.resource_subpath(
-                        pulumi_state_splitter.model.Resource(
-                            type=self.stack_name.ROOT_STACK_TYPE,
-                            urn=self.stack_name.urn,
-                        ),
-                    )
-                )
+                self._load_resource(stack_resource_path)
             ]
         else:
             self.state.checkpoint.latest.resources = (

--- a/utilities/pulumi_state_splitter/tests/test_integration.py
+++ b/utilities/pulumi_state_splitter/tests/test_integration.py
@@ -286,3 +286,44 @@ class TestPulumiIntegration(util.TmpDirTest):
         self._check_outputs(stack_with_reference.name, {"test-ref-output": test_string})
 
         self.assertFalse((self._tmp_dir / ".pulumi").exists())
+
+    @parameterized.parameterized.expand([[False], [True]])
+    def test_unititialized_outputs(self, outputs):
+        """Test that we support unsplitting with uninitialized stacks."""
+
+        def bare_pulumi_program():
+            pass
+
+        unsplitter_all = pulumi_state_splitter.split.Unsplitter(
+            backend_dir=self._tmp_dir,
+            stacks_names=None,
+        )
+
+        with unsplitter_all:
+            self._create_stack("bare-1", bare_pulumi_program)
+
+        second_name = pulumi_state_splitter.stored_state.StackName(
+            project=self._PROJECT_NAME,
+            stack="bare-2",
+        )
+
+        unsplitter_second = pulumi_state_splitter.split.Unsplitter(
+            backend_dir=self._tmp_dir,
+            stacks_names=[second_name] if outputs else None,
+            outputs=outputs,
+        )
+
+        with unsplitter_second:
+            second_stack = self._create_stack(
+                second_name.stack,
+                bare_pulumi_program,
+            )
+
+        with unsplitter_second:
+            summary = second_stack.up().summary
+
+        self.assertEqual(summary.result, "succeeded")
+        self.assertEqual(
+            summary.resource_changes,
+            {"create": 1},
+        )

--- a/utilities/pulumi_state_splitter/tests/test_integration.py
+++ b/utilities/pulumi_state_splitter/tests/test_integration.py
@@ -202,14 +202,15 @@ class TestPulumiIntegration(util.TmpDirTest):
         def pulumi_program_with_output():
             pulumi.export("test-output", test_string)
 
-        stack_with_output = self._create_stack(
-            "with-output", pulumi_program_with_output
-        )
-
         output_unsplitter = pulumi_state_splitter.split.Unsplitter(
             backend_dir=self._tmp_dir,
             stacks_names=None,
         )
+
+        with output_unsplitter:
+            stack_with_output = self._create_stack(
+                "with-output", pulumi_program_with_output
+            )
 
         with output_unsplitter:
             summary = stack_with_output.up().summary


### PR DESCRIPTION
when outputs_only.

Best reviewed commit by commit.