### PR TITLE
pulumi-state-splitter: pyproject.toml: move style-tests to dev dependencies

### DIFF
--- a/utilities/pulumi_state_splitter/pyproject.toml
+++ b/utilities/pulumi_state_splitter/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "pydantic>=2.5.3,<3",
     "pyyaml>=6.0.1,<7",
     "click>=8.1.7,<9",
-    "style-tests",
 ]
 
 [project.scripts]
@@ -29,6 +28,7 @@ dev = [
     "pulumi-command>=0.10.0",
     "typeguard>=4.1.5,<5",
     "parameterized>=0.9.0,<0.10",
+    "style-tests",
 ]
 
 [tool.uv]

--- a/utilities/pulumi_state_splitter/uv.lock
+++ b/utilities/pulumi_state_splitter/uv.lock
@@ -501,7 +501,6 @@ dependencies = [
     { name = "click" },
     { name = "pydantic" },
     { name = "pyyaml" },
-    { name = "style-tests" },
 ]
 
 [package.dev-dependencies]
@@ -510,6 +509,7 @@ dev = [
     { name = "parameterized" },
     { name = "pulumi" },
     { name = "pulumi-command" },
+    { name = "style-tests" },
     { name = "typeguard" },
 ]
 
@@ -518,7 +518,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7,<9" },
     { name = "pydantic", specifier = ">=2.5.3,<3" },
     { name = "pyyaml", specifier = ">=6.0.1,<7" },
-    { name = "style-tests", git = "https://github.com/house-reliability-engineering/python.git?subdirectory=style_tests" },
 ]
 
 [package.metadata.requires-dev]
@@ -527,6 +526,7 @@ dev = [
     { name = "parameterized", specifier = ">=0.9.0,<0.10" },
     { name = "pulumi", specifier = ">=3.99.0,<4" },
     { name = "pulumi-command", specifier = ">=0.10.0" },
+    { name = "style-tests", git = "https://github.com/house-reliability-engineering/python.git?subdirectory=style_tests" },
     { name = "typeguard", specifier = ">=4.1.5,<5" },
 ]
 


### PR DESCRIPTION
Best review commit by commit.